### PR TITLE
Update 2025 AID-G third-semester timetable

### DIFF
--- a/registry/v2/files/2025/aid-g/3.json
+++ b/registry/v2/files/2025/aid-g/3.json
@@ -10,7 +10,11 @@
     "B": {
       "name": "Modelling Simulation and Analysis",
       "code": "23AID201",
-      "faculty": ["Dr. D. N. Kiran Pandiri", "Dr. Sirisha Tadepalli"],
+      "faculty": [
+        "Dr. D. N. Kiran Pandiri",
+        "Dr. Sirisha Tadepalli",
+        "Ms. Malavika V. S."
+      ],
       "shortName": "MSA"
     },
     "C": {
@@ -40,19 +44,23 @@
     "G": {
       "name": "Introduction to Computer Networks",
       "code": "23AID206",
-      "faculty": ["Dr. Rajesh M.", "Mr. Vishwas H. N."],
+      "faculty": ["Dr. Rajesh M.", "Mr. Vishwas H. N.", "Mr. Sravankumar"],
       "shortName": "ICN"
     },
     "H": {
       "name": "Strategic Lessons from Mahabharata",
       "code": "22ADM201",
-      "faculty": [],
+      "faculty": ["Ms. Bhavya Suresh"],
       "shortName": "ADM"
     },
     "CIR": {
       "name": "Life Skills for Engineers I",
       "code": "23LSE201",
-      "faculty": [],
+      "faculty": [
+        "Ms. Karishma Nair N.",
+        "Mr. Sivakumar K. M.",
+        "Ms. Nilakshee Kalita"
+      ],
       "shortName": "LSE"
     }
   },
@@ -62,7 +70,7 @@
     "Monday": ["A_LAB", "A_LAB", "A_LAB", "C_LAB", "C_LAB", "B", "FREE"],
     "Tuesday": ["H", "A", "F", "D_LAB", "D_LAB", "G_LAB", "G_LAB"],
     "Wednesday": ["G", "C", "D", "B_LAB", "B_LAB", "E", "A"],
-    "Thursday": ["B", "G", "E", "C", "A", "F_LAB", "F_LAB"],
-    "Friday": ["F", "CIR", "CIR", "CIR", "D", "E_LAB", "E_LAB"]
+    "Thursday": ["B", "G", "E", "C", "D", "F_LAB", "F_LAB"],
+    "Friday": ["F", "CIR", "CIR", "CIR", "A", "E_LAB", "E_LAB"]
   }
 }


### PR DESCRIPTION
## What changed

- swap the Thursday and Friday 11:50 slots for Mathematics and SDCS to match the latest timetable
- add the newly listed co-faculty for Modelling Simulation and Analysis and Computer Networks
- add faculty for Strategic Lessons from Mahabharata and Life Skills for Engineers I
- keep the Monday counselling period as `FREE`, consistent with registry semantics

## Why

The existing 2025 AID-G semester-3 registry entry differed from the timetable effective 27 July 2026 and omitted several listed faculty members.

## Validation

- full schema and semantic validation: 99/99 timetable files passed
- `git diff --check` passed