### PR TITLE
Render 2023 RAE project periods as free

### DIFF
--- a/registry/v2/files/2023/rae-n/7.json
+++ b/registry/v2/files/2023/rae-n/7.json
@@ -91,8 +91,8 @@
   "schedule": {
     "Monday": ["A", "B", "elective1Slot", "CNCL_LAB", "CNCL_LAB", "cyberTheorySlot", "cyberTheorySlot"],
     "Tuesday": ["A", "elective1Slot", "B", "cyberLabSlot", "cyberLabSlot", "SI", "SI"],
-    "Wednesday": ["B_LAB", "B_LAB", "B_LAB", "elective1Slot", "A", "PROJ", "PROJ"],
-    "Thursday": ["FREE", "FREE", "FREE", "FREE", "FREE", "PROJ", "PROJ"],
-    "Friday": ["PROJ", "PROJ", "PROJ", "PROJ", "PROJ", "PROJ", "PROJ"]
+    "Wednesday": ["B_LAB", "B_LAB", "B_LAB", "elective1Slot", "A", "FREE", "FREE"],
+    "Thursday": ["FREE", "FREE", "FREE", "FREE", "FREE", "FREE", "FREE"],
+    "Friday": ["FREE", "FREE", "FREE", "FREE", "FREE", "FREE", "FREE"]
   }
 }


### PR DESCRIPTION
## What changed

- render all Project Phase I periods in the 2023 RAE semester-7 schedule as `FREE`
- retain the Project Phase I subject metadata
- leave the attended Summer Internship periods unchanged

## Why

The earlier timetable update mapped the source sheet's Project Phase I blocks directly to the project subject. These periods should be free in the rendered timetable.

## Validation

- full schema and semantic validation: 99/99 timetable files passed
- `git diff --check` passed