### PR TITLE
Fix 2026 EAC Thursday heritage slot

### DIFF
--- a/registry/v2/files/2026/eac-k/1.json
+++ b/registry/v2/files/2026/eac-k/1.json
@@ -85,7 +85,7 @@
     "Monday": ["C", "D", "E", "B", "A", "monAfternoonLab", "monAfternoonLab"],
     "Tuesday": ["C_LAB", "C_LAB", "C_LAB", "B", "D", "G", "FREE"],
     "Wednesday": ["B", "A", "I", "wedMidLab", "wedMidLab", "FREE", "FREE"],
-    "Thursday": ["A", "FREE", "I", "E", "FREE", "FREE", "FREE"],
+    "Thursday": ["A", "FREE", "I", "E", "H", "FREE", "FREE"],
     "Friday": ["E", "H", "B", "G", "D", "FREE", "FREE"]
   }
 }


### PR DESCRIPTION
## What changed

- set Thursday period 5 for 2026 EAC-K semester 1 to Foundations of Indian Heritage

## Why

The slot was incorrectly marked `FREE` in the registry.

## Validation

- full schema and semantic validation: 99/99 timetable files passed
- `git diff --check` passed