### PR TITLE
Update 2026 EAC revised timetable

### DIFF
--- a/registry/v2/files/2026/eac-k/1.json
+++ b/registry/v2/files/2026/eac-k/1.json
@@ -16,7 +16,12 @@
     "C": {
       "name": "Problem Solving and Algorithmic Thinking",
       "code": "23ECE102",
-      "faculty": ["Dr. Karnena Rohit Kumar", "Mr. Pavan Sai"],
+      "faculty": [
+        "Dr. Priya Gupta",
+        "Mr. Pavan Sai",
+        "Mr. Aniket Kumbhar",
+        "Mr. Rayee Jaswanth"
+      ],
       "shortName": "PSAT"
     },
     "D": {
@@ -34,7 +39,13 @@
     "F": {
       "name": "Electrical Engineering Laboratory",
       "code": "23ECE181",
-      "faculty": ["Dr. Phani Raj Harivanam", "Dr. Patthi Aruna", "Mr. Giriraja C. V."],
+      "faculty": [
+        "Dr. Phani Raj Harivanam",
+        "Dr. Patthi Aruna",
+        "Dr. Priya Gupta",
+        "Mr. Giriraja C. V.",
+        "Mr. Aniket Kumbhar"
+      ],
       "shortName": "EE Lab"
     },
     "G": {
@@ -85,7 +96,7 @@
     "Monday": ["C", "D", "E", "B", "A", "monAfternoonLab", "monAfternoonLab"],
     "Tuesday": ["C_LAB", "C_LAB", "C_LAB", "B", "D", "G", "FREE"],
     "Wednesday": ["B", "A", "I", "wedMidLab", "wedMidLab", "FREE", "FREE"],
-    "Thursday": ["A", "FREE", "I", "E", "H", "FREE", "FREE"],
+    "Thursday": ["FREE", "A", "I", "E", "H", "FREE", "FREE"],
     "Friday": ["E", "H", "B", "G", "D", "FREE", "FREE"]
   }
 }


### PR DESCRIPTION
## What changed

- move Thursday counselling to period 1 and Nature Inspired Engineering to period 2
- update the PSAT teaching team from the revised timetable
- add the revised K1/K2 Electrical Engineering Laboratory faculty
- retain Ms. Sanjana K. Chandran as the canonical Technical Communication faculty name

## Why

The latest 2026 EAC-K timetable revises Thursday morning and lists updated faculty assignments.

## Validation

- full schema and semantic validation: 99/99 timetable files passed
- `git diff --check` passed