### PR TITLE
Update 2025 and 2026 batch timetables

### DIFF
--- a/registry/v2/files/2025/aie-f/3.json
+++ b/registry/v2/files/2025/aie-f/3.json
@@ -186,11 +186,11 @@
     "Wednesday": [
       "G",
       "A",
-      "C",
+      "FREE",
       "D_LAB",
       "D_LAB",
       "fe1",
-      "FREE"
+      "C"
     ],
     "Thursday": [
       "D",

--- a/registry/v2/files/2025/cse-a/3.json
+++ b/registry/v2/files/2025/cse-a/3.json
@@ -46,7 +46,7 @@
     "H": {
       "name": "Strategic Lessons from Mahabharata",
       "code": "22ADM201",
-      "faculty": [],
+      "faculty": ["Dr. Saurabh Sharma"],
       "shortName": "SLM"
     }
   },
@@ -71,9 +71,9 @@
   },
   "schedule": {
     "Monday": ["A_LAB", "A_LAB", "A_LAB", "C_LAB", "C_LAB", "H", "D"],
-    "Tuesday": ["C", "E", "A", "tuesdayLab", "tuesdayLab", "B", "FREE"],
+    "Tuesday": ["C", "E", "A", "tuesdayLab", "tuesdayLab", "FREE", "B"],
     "Wednesday": ["C", "E", "E", "B", "A", "D_LAB", "D_LAB"],
-    "Thursday": ["C", "CIR", "CIR", "CIR", "D", "E", "FREE"],
+    "Thursday": ["C", "CIR", "CIR", "CIR", "FREE", "E", "D"],
     "Friday": ["D", "A", "B", "fridayLab", "fridayLab", "E_LAB", "E_LAB"]
   }
 }

--- a/registry/v2/files/2026/cse-b/1.json
+++ b/registry/v2/files/2026/cse-b/1.json
@@ -4,7 +4,7 @@
     "A": {
       "name": "Manufacturing Practice",
       "code": "23MEE115",
-      "faculty": ["Ms. Divya Sharma S. G.", "Dr. Shankara"],
+      "faculty": ["Dr. Vinod Kotebavi", "Dr. Shankara"],
       "shortName": "MP"
     },
     "B": {
@@ -28,7 +28,7 @@
     "E": {
       "name": "Basic Electrical and Electronics Engineering Practice",
       "code": "23EEE184",
-      "faculty": ["Dr. S. Syama", "Dr. Sujit Kumar", "Ms. Archana Mohan"],
+      "faculty": ["Dr. S. Syama", "New Faculty", "Dr. Sujit Kumar", "Ms. U. Kruthika"],
       "shortName": "BEEEP"
     },
     "F": {
@@ -70,6 +70,7 @@
     "wedMorningLab": {
       "match": "batch",
       "choices": {
+        "b1": "E_LAB",
         "b2": "A_LAB"
       }
     },
@@ -84,19 +85,13 @@
       "choices": {
         "b2": "F_LAB"
       }
-    },
-    "thuAfternoonLab": {
-      "match": "batch",
-      "choices": {
-        "b1": "E_LAB"
-      }
     }
   },
   "schedule": {
     "Monday": ["C_LAB", "C_LAB", "C_LAB", "FREE", "FREE", "D", "B"],
     "Tuesday": ["F", "D", "C", "tueMidLab", "tueMidLab", "B", "FREE"],
     "Wednesday": ["wedMorningLab", "wedMorningLab", "wedMorningLab", "C", "FREE", "wedAfternoonLab", "wedAfternoonLab"],
-    "Thursday": ["G", "H", "B", "thuMidLab", "thuMidLab", "thuAfternoonLab", "thuAfternoonLab"],
+    "Thursday": ["G", "H", "B", "thuMidLab", "thuMidLab", "FREE", "FREE"],
     "Friday": ["D", "C", "H", "B_LAB", "B_LAB", "FREE", "G"]
   }
 }


### PR DESCRIPTION
## What changed

### 2025 AIE-F semester 3
- move Wednesday Operating Systems from period 3 to period 7
- render Wednesday period 3 counselling as `FREE`

### 2025 CSE-A semester 3
- move Tuesday Digital Electronics to period 7 and render counselling as `FREE`
- move Thursday DBMS to period 7 and render evaluation as `FREE`
- add Dr. Saurabh Sharma to Strategic Lessons from Mahabharata

### 2026 CSE-B semester 1
- route B1's electrical-practice lab to Wednesday morning
- remove the obsolete B1 Thursday-afternoon lab
- update Manufacturing Practice and electrical-practice faculty from the revised sheet

## Why

The three supplied official timetable sheets differ from the current registry schedules and faculty assignments.

## Validation

- visually verified all three rendered PDF pages
- full schema and semantic validation: 99/99 timetable files passed
- `git diff --check` passed