### PR TITLE
Fix 2025 EAC Tuesday slots

### DIFF
--- a/registry/v2/files/2025/eac-k/3.json
+++ b/registry/v2/files/2025/eac-k/3.json
@@ -127,7 +127,7 @@
   },
   "schedule": {
     "Monday": ["DSL_LAB", "DSL_LAB", "DSL_LAB", "A", "C", "B", "D"],
-    "Tuesday": ["B", "D", "F", "tuesdayLab", "tuesdayLab", "C", "E"],
+    "Tuesday": ["F", "D", "B", "tuesdayLab", "tuesdayLab", "C", "E"],
     "Wednesday": ["C", "B", "A", "SPL_LAB", "SPL_LAB", "F", "FREE"],
     "Thursday": ["thursdayLab", "thursdayLab", "thursdayLab", "F", "G", "G", "G"],
     "Friday": ["A", "C", "D", "B", "F", "INSTR", "FREE"]


### PR DESCRIPTION
## What changed

- set Tuesday period 1 to Data Structures and Algorithms
- set Tuesday period 3 to Signal Processing

## Why

The two subjects were exchanged in the current 2025 EAC semester-3 registry schedule. The supplied timetable confirms the remaining schedule, faculty, and E1/E2 lab routing.

## Validation

- visually verified the supplied timetable image
- full schema and semantic validation: 99/99 timetable files passed
- `git diff --check` passed